### PR TITLE
Train text embeddings and compare with speech2vec text embeddings

### DIFF
--- a/more_experiments/train_embeddings_helpers.py
+++ b/more_experiments/train_embeddings_helpers.py
@@ -1,0 +1,65 @@
+import os
+import pandas as pd
+import spacy
+
+def get_alignment_filenames(path_to_alignments_folder):
+    '''Get all file names in the annotated word alignments'''
+    root_path = 'data/LibriSpeech-Alignments/LibriSpeech_Text_Alignments/'
+    folders = ['dev-clean', 'dev-other', 'test-clean', 'test-other', 'train-clean-100', 'train-clean-360', 'train-other-500']
+    filenames = dict()
+    for folder in folders:
+        grab_files = []
+        for path, subdirs, files in os.walk(root_path + folder):
+            for name in files:
+                grab_files.append(os.path.join(path, name))
+        filenames[folder] = grab_files
+    return filenames # Returns a dictionarty with {subfolder_name:[filenames_in_subfolder]}
+
+def get_text_from_files(filenames_dict):
+    '''Will create a dataframe per folder, with all the text combined as the column
+    Questions:
+    Do we need to keep silence?
+    '''
+    all_folders_df = pd.DataFrame()
+    for folder, filenames in filenames_dict.items():
+        folder_df = pd.DataFrame()
+        for filename in filenames:
+            if filename[-3:] == 'txt':
+                file_text = extract_text_single_file(filename)
+                folder_text = {'Folder':[folder], 'Filename':[filename], 'Text':[file_text]}
+                text_df = pd.DataFrame(folder_text)
+                folder_df = folder_df.append(text_df)
+        all_folders_df = all_folders_df.append(folder_df)
+    return all_folders_df
+
+def extract_text_single_file(file_path):
+    with open(file_path, 'r') as f:
+        content = f.read().splitlines()
+    all_text = ''
+    for line in content:
+        text = line.split()[1].split(',')
+        text = [word for word in text if word.isalnum()]
+        all_text += ' '.join(text) + ' '
+    return all_text
+
+def main():
+    filenames_dict = get_alignment_filenames('data/LibriSpeech-Alignments/LibriSpeech_Text_Alignments')
+    df = get_text_from_files(filenames_dict)
+    return df
+
+class TextPreprocess():
+    def __init__(self):
+        self.nlp = spacy.load('en')
+
+    def lemmatize(self, text_chunk):
+        text_model = self.nlp(text_chunk)
+        new_chunk = ' '.join([word.lemma_ if word.lemma_ != '-PRON-' else word.text for word in text_model])
+        return new_chunk
+
+    def remove_stopwords(self, text_chunk):
+        text_model = self.nlp(text_chunk)
+        new_chunk = ' '.join([word.text for word in text_model if not word.is_stop ])
+        return new_chunk
+
+if __name__ == "__main__":
+    main()

--- a/more_experiments/train_librispeech_text_embeddings.ipynb
+++ b/more_experiments/train_librispeech_text_embeddings.ipynb
@@ -1,0 +1,511 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "Python 3.7.7 64-bit ('nlp_capstone': conda)",
+   "display_name": "Python 3.7.7 64-bit ('nlp_capstone': conda)",
+   "metadata": {
+    "interpreter": {
+     "hash": "4832c2ea01ef7705b314525d62e7cb3e1c2a207ef0cd68f92e768949057f3ba4"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import train_embeddings_helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = train_embeddings_helpers.main()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "(7375, 3)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_df = df[(df['Folder'] == 'train-clean-360') | (df['Folder'] == 'train-clean-100')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "(2682, 3)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "source": [
+    "training_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "train-clean-360    2097\n",
+       "train-clean-100     585\n",
+       "Name: Folder, dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "source": [
+    "training_df.Folder.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Text preprocessing: \n",
+    "# lowercase text\n",
+    "training_df.Text = training_df.Text.str.lower()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocess with SpaCy - Init preprocessing class\n",
+    "preproc = train_embeddings_helpers.TextPreprocess()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CPU times: user 7min 18s, sys: 42.8 s, total: 8min 1s\nWall time: 8min 3s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# lemmatize text - we don't need it as FastText includes morphological structure\n",
+    "training_df.Text2 = training_df.Text.apply(preproc.lemmatize)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CPU times: user 7min 5s, sys: 41.8 s, total: 7min 47s\nWall time: 7min 49s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# remove stop words\n",
+    "training_df.Text2 = training_df.Text.apply(preproc.remove_stopwords)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace multiple spaces with one\n",
+    "training_df.Text2 = training_df.Text2.str.replace('[ ]{2,}', ' ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gensim.models.fasttext import FastText "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "2682"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 14
+    }
+   ],
+   "source": [
+    "# vocab is a list of text chunks, not a list of sentences - does it matter?\n",
+    "vocab = training_df.Text2.to_list()\n",
+    "vocab = [chunk.split() for chunk in vocab]\n",
+    "len(vocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CPU times: user 1min 31s, sys: 1.53 s, total: 1min 33s\nWall time: 38.7 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Init model with following parameters\n",
+    "# Rest of parameters are default, see: https://radimrehurek.com/gensim_3.8.3/auto_examples/tutorials/run_fasttext.html#sphx-glr-auto-examples-tutorials-run-fasttext-py\n",
+    "model = FastText(vocab,\n",
+    "    sg=1, #skipgram, not cbow\n",
+    "    size=50, # from the speech2vec authors\n",
+    "    window=2) # from the speech2vec authors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 61
+    }
+   ],
+   "source": [
+    "'freedom' in model.wv.vocab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "[('prosperity', 0.8996621370315552),\n",
+       " ('welfare', 0.8982266187667847),\n",
+       " ('censorship', 0.8971235752105713),\n",
+       " ('discipleship', 0.8961487412452698),\n",
+       " ('championship', 0.8959816694259644),\n",
+       " ('victuals', 0.8880187273025513),\n",
+       " ('immunity', 0.8850102424621582),\n",
+       " ('independence', 0.8830586671829224),\n",
+       " ('freedmen', 0.8828678131103516),\n",
+       " ('depends', 0.8816428780555725)]"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 60
+    }
+   ],
+   "source": [
+    "model.wv.most_similar('freedom')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gensim.test.utils import get_tmpfile\n",
+    "fname = get_tmpfile(\"librispeech.model\")\n",
+    "model.save(fname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load speech2vec paper pretrained vectors\n",
+    "from gensim.test.utils import datapath\n",
+    "from gensim.models import KeyedVectors\n",
+    "speech2vec = KeyedVectors.load_word2vec_format(datapath('path/to/vectors'), binary=False) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Comparing embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "# Assumes the word-embeddings-benchmark repo is available\n",
+    "from web.datasets.similarity import fetch_MEN, fetch_WS353, fetch_SimLex999\n",
+    "from web.embeddings import fetch_GloVe\n",
+    "from web.evaluate import evaluate_similarity\n",
+    "from web.embedding import Embedding, Vocabulary\n",
+    "from gensim.models import Word2Vec\n",
+    "from gensim.models import KeyedVectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\nDataset created in /Users/susan_jose/web_data/similarity\n\n"
+     ]
+    }
+   ],
+   "source": [
+    "tasks = {\n",
+    "    \"MEN\": fetch_MEN(),\n",
+    "    \"WS353\": fetch_WS353(),\n",
+    "    \"SIMLEX999\": fetch_SimLex999()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_embeddings = model.wv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "our_embeddings = Embedding(Vocabulary(list(model_embeddings.vocab.keys())), model_embeddings.vectors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speech2vec_embeddings = Embedding(Vocabulary(list(speech2vec.vocab.keys())), speech2vec.vectors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "array([-0.18957646, -0.16634491,  0.17309435, -0.10543959,  0.40227103,\n",
+       "        0.46282825,  0.36515525,  0.40559214, -0.04941564, -0.14805059,\n",
+       "       -0.43525735,  0.23659192,  0.24746099, -0.40600204,  0.47878677,\n",
+       "        0.03553356,  0.38474318,  0.5425196 ,  0.2359668 , -0.31592923,\n",
+       "        0.00404495,  0.8307184 ,  0.59101576,  0.30376983,  0.4759713 ,\n",
+       "        0.37360162, -0.21704458,  0.02078121, -0.7336424 , -0.25237545,\n",
+       "        0.15958194, -0.14043784, -0.47706226,  0.06924255, -0.10315103,\n",
+       "       -0.33340412,  0.22820638, -0.12231199, -0.28851575,  0.09375487,\n",
+       "       -1.1073669 ,  0.38313985, -0.07264016, -0.11328681,  0.45372888,\n",
+       "        0.273097  ,  0.22372684,  0.3424083 ,  0.5861805 , -0.0139005 ],\n",
+       "      dtype=float32)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 64
+    }
+   ],
+   "source": [
+    "our_embeddings['friend']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "array([ 9.3413e-02, -2.8946e-02,  4.7311e-02, -6.3347e-01,  8.1125e-02,\n",
+       "       -5.3966e-01,  2.4762e-01,  2.5534e-01,  7.6590e-01,  6.0520e-01,\n",
+       "       -2.6295e-01, -6.2333e-01,  1.0154e-03,  4.5374e-02, -2.9838e-01,\n",
+       "        1.5166e-01, -4.0217e-02, -2.2317e-01,  3.7647e-01, -9.2910e-02,\n",
+       "       -3.9502e-01, -8.6376e-06,  3.9423e-02,  1.4150e-01, -2.2859e-01,\n",
+       "        2.7005e-02,  8.4433e-02, -2.0136e-01, -1.5508e-01, -9.8139e-02,\n",
+       "        9.0681e-02,  7.5589e-01,  1.8953e-02,  2.4214e-01, -4.0025e-01,\n",
+       "       -9.9142e-02,  1.6269e-01, -8.4639e-02,  1.2320e-01, -3.2370e-01,\n",
+       "        4.4290e-01,  3.1282e-01,  2.5814e-02,  8.5238e-02,  5.5223e-01,\n",
+       "        1.7657e-01,  2.3437e-01, -1.0683e-01, -3.2922e-01,  1.4219e-01],\n",
+       "      dtype=float32)"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 65
+    }
+   ],
+   "source": [
+    "speech2vec_embeddings['friend']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s2v_emb_no_nan = {}\n",
+    "nans_encountered = 0\n",
+    "for i in range(len(vocab)):    \n",
+    "    if vocab[i] == vocab[i]:\n",
+    "        word2embedding_without_nans[vocab[i]] = embeddings[i]\n",
+    "    else: nans_encountered += 1\n",
+    "\n",
+    "print(f'Encountered rows with nan values: {nans_encountered}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Missing 701 words. Will replace them with mean vector\n",
+      "Missing 92 words. Will replace them with mean vector\n",
+      "Missing 113 words. Will replace them with mean vector\n",
+      "Spearman correlation of scores on MEN -0.05461907793994027\n",
+      "Spearman correlation of scores on WS353 0.08576695593634177\n",
+      "Spearman correlation of scores on SIMLEX999 0.05970123870565761\n"
+     ]
+    }
+   ],
+   "source": [
+    "for name, data in tasks.items():\n",
+    "    print(\"Spearman correlation of scores on {} {}\".format(name, evaluate_similarity(our_embeddings, data.X, data.y)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "Missing 392 words. Will replace them with mean vector\n",
+      "Missing 61 words. Will replace them with mean vector\n",
+      "Missing 24 words. Will replace them with mean vector\n",
+      "Spearman correlation of scores on MEN 0.6056592803599269\n",
+      "Spearman correlation of scores on WS353 0.43349390636024643\n",
+      "Spearman correlation of scores on SIMLEX999 0.25938770901422736\n"
+     ]
+    }
+   ],
+   "source": [
+    "for name, data in tasks.items():\n",
+    "    print(\"Spearman correlation of scores on {} {}\".format(name, evaluate_similarity(speech2vec_embeddings, data.X, data.y)))"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
The goal of this exercise is to further understand where our implementation and the speech2vec authors' implementation differs.

In the paper, they mention they train word embeddings based on text using the fasttext implementation, to compare against their embeddings based on audio (see sections 3.3 and 3.4 in the paper). They also make both the audio-based and text-based vectors available at https://github.com/iamyuanchung/speech2vec-pretrained-vectors.

This code does the following:
- Takes the same dataset sample from the librispeech data as was used in the paper
- Trains a word2vec model using the Fasttext implementation available in Gensim, via skipgram approach
- Applies some benchmarks to compare both sets of vectors (room for improvement, see #7 )